### PR TITLE
Faster split algorithm based on integral image

### DIFF
--- a/cvlib/include/cvlib.hpp
+++ b/cvlib/include/cvlib.hpp
@@ -16,8 +16,8 @@ namespace cvlib
 /// \param stddev, in - threshold to treat regions as homogeneous
 /// \return segmented image
 cv::Mat split_and_merge(const cv::Mat& image, double stddev);
-
-/// \brief Segment texuture on passed image according to sample in ROI
+cv::Mat only_split(const cv::Mat& image, double stddev);
+    /// \brief Segment texuture on passed image according to sample in ROI
 /// \param image, in - input image
 /// \param roi, in - region with sample texture on passed image
 /// \param eps, in - threshold parameter for texture's descriptor distance

--- a/cvlib/src/split_and_merge.cpp
+++ b/cvlib/src/split_and_merge.cpp
@@ -10,55 +10,56 @@
 #define MIN_SPLIT_SIZE 5
 #define DELTA_MEAN 10
 
-
-
 std::map<double, std::pair<cv::Range, cv::Range>> region_history;
 
-cv::Mat integralImg, sqIntegralImg;
+cv::Mat integralImg, sqIntegralImg, cpImg;
 
 namespace
 {
-
-// mean and std on integral images 
+// mean and std on integral images
 void split_region(int x1, int y1, int x2, int y2, const double& stddev)
 {
-	int S1 = integralImg.at<int>(y2, x2) + integralImg.at<int>(y1, x1) - integralImg.at<int>(y2, x1) - integralImg.at<int>(y1, x2);
-	double S2 = sqIntegralImg.at<double>(y2, x2) + sqIntegralImg.at<double>(y1, x1) - sqIntegralImg.at<double>(y2, x1) - sqIntegralImg.at<double>(y1, x2);
-	double mean = double(S1) / (x2 - x1) / (y2 - y1);
-	double std = sqrt(1.0 / (x2 - x1) / (y2 - y1) * (S2 - 2 * mean * S1) + mean * mean);
+    int S1 = integralImg.at<int>(y2, x2) + integralImg.at<int>(y1, x1) - integralImg.at<int>(y2, x1) - integralImg.at<int>(y1, x2);
+    double S2 = sqIntegralImg.at<double>(y2, x2) + sqIntegralImg.at<double>(y1, x1) - sqIntegralImg.at<double>(y2, x1) - sqIntegralImg.at<double>(y1, x2);
+    double mean = double(S1) / (x2 - x1) / (y2 - y1);
+    double std = sqrt(1.0 / (x2 - x1) / (y2 - y1) * (S2 - 2 * mean * S1) + mean * mean);
 
-	if (std <= stddev || (x2 - x1) < MIN_SPLIT_SIZE || (y2 - y1) < MIN_SPLIT_SIZE)
-	{
-		region_history.emplace(mean, std::pair<cv::Range, cv::Range>(cv::Range(y1, y2), cv::Range(x1, x2)));
-		return;
-	}
+    if (std <= stddev || (x2 - x1) < MIN_SPLIT_SIZE || (y2 - y1) < MIN_SPLIT_SIZE)
+    {
+        region_history.emplace(mean, std::pair<cv::Range, cv::Range>(cv::Range(y1, y2), cv::Range(x1, x2)));
+        // cpImg(cv::Range(y1, y2), cv::Range(x1, x2)).setTo(int(mean));
+        return;
+    }
 
-	split_region(x1, y1, (x1 + x2) / 2, (y1 + y2) / 2, stddev);
-	split_region((x1 + x2) / 2, y1, x2, (y1 + y2) / 2, stddev);
-	split_region(x1, (y1 + y2) / 2, (x1 + x2) / 2, y2, stddev);
-	split_region((x1 + x2) / 2, (y1 + y2) / 2, x2, y2, stddev);
+    split_region(x1, y1, (x1 + x2) / 2, (y1 + y2) / 2, stddev);
+    split_region((x1 + x2) / 2, y1, x2, (y1 + y2) / 2, stddev);
+    split_region(x1, (y1 + y2) / 2, (x1 + x2) / 2, y2, stddev);
+    split_region((x1 + x2) / 2, (y1 + y2) / 2, x2, y2, stddev);
 }
 
 void split_image(cv::Mat& image, const double& stddev)
 {
-	cv::Mat int_img, squared_int_img;
-	cv::integral(image, integralImg, sqIntegralImg);
+    cv::Mat int_img, squared_int_img;
+    cv::integral(image, integralImg, sqIntegralImg);
 
-	split_region(0, 0, image.cols, image.rows, stddev);
+    split_region(0, 0, image.cols, image.rows, stddev);
 }
 
 void merge_image(cv::Mat& image)
 {
-	auto elem = region_history.begin();
-	double next_val = elem->first + DELTA_MEAN;
-	while (elem != region_history.end())
-	{
-		if (elem->first > next_val)
-			next_val += DELTA_MEAN;
-		image(elem->second.first, elem->second.second).setTo(int(next_val - DELTA_MEAN / 2));
-		elem++;
-	}
-	
+    auto elem = region_history.begin();
+    
+    double mean_val = elem->first + DELTA_MEAN;
+    while (elem != region_history.end())
+    {
+        if (elem->first > mean_val)
+            mean_val += DELTA_MEAN;
+        int new_val = mean_val - DELTA_MEAN / 2;
+        if (new_val > 255)
+            new_val = 255;
+        image(elem->second.first, elem->second.second).setTo(new_val);
+        elem++;
+    }
 }
 } // namespace
 
@@ -67,17 +68,36 @@ namespace cvlib
 cv::Mat split_and_merge(const cv::Mat& image, double stddev)
 {
     // split part
-    cv::Mat res = image; // copy
+    cv::Mat res = image;
     split_image(res, stddev);
 
     // merge part
-	merge_image(res);
+    merge_image(res);
 
-	// clear global vars
-	integralImg.release();
-	sqIntegralImg.release();
-	region_history.clear();
+    // clear global vars
+    integralImg.release();
+    sqIntegralImg.release();
+    region_history.clear();
 
     return res;
+}
+
+cv::Mat only_split(const cv::Mat& image, double stddev)
+{
+    // clear global vars
+    cpImg.release();
+    integralImg.release();
+    sqIntegralImg.release();
+    region_history.clear();
+    // split part
+    cpImg = image;
+    split_image(cpImg, stddev);
+
+	for (auto elem = region_history.begin(); elem != region_history.end(); ++elem)
+	{
+        cpImg((elem->second).first, (elem->second).second).setTo(int(elem->first));
+	}
+
+    return cpImg;
 }
 } // namespace cvlib

--- a/cvlib/src/split_and_merge.cpp
+++ b/cvlib/src/split_and_merge.cpp
@@ -5,28 +5,60 @@
  */
 
 #include "cvlib.hpp"
+#include <map>
+
+#define MIN_SPLIT_SIZE 5
+#define DELTA_MEAN 10
+
+
+
+std::map<double, std::pair<cv::Range, cv::Range>> region_history;
+
+cv::Mat integralImg, sqIntegralImg;
 
 namespace
 {
-void split_image(cv::Mat image, double stddev)
+
+// mean and std on integral images 
+void split_region(int x1, int y1, int x2, int y2, const double& stddev)
 {
-    cv::Mat mean;
-    cv::Mat dev;
-    cv::meanStdDev(image, mean, dev);
+	int S1 = integralImg.at<int>(y2, x2) + integralImg.at<int>(y1, x1) - integralImg.at<int>(y2, x1) - integralImg.at<int>(y1, x2);
+	double S2 = sqIntegralImg.at<double>(y2, x2) + sqIntegralImg.at<double>(y1, x1) - sqIntegralImg.at<double>(y2, x1) - sqIntegralImg.at<double>(y1, x2);
+	double mean = double(S1) / (x2 - x1) / (y2 - y1);
+	double std = sqrt(1.0 / (x2 - x1) / (y2 - y1) * (S2 - 2 * mean * S1) + mean * mean);
 
-    if (dev.at<double>(0) <= stddev)
-    {
-        image.setTo(mean);
-        return;
-    }
+	if (std <= stddev || (x2 - x1) < MIN_SPLIT_SIZE || (y2 - y1) < MIN_SPLIT_SIZE)
+	{
+		region_history.emplace(mean, std::pair<cv::Range, cv::Range>(cv::Range(y1, y2), cv::Range(x1, x2)));
+		return;
+	}
 
-    const auto width = image.cols;
-    const auto height = image.rows;
+	split_region(x1, y1, (x1 + x2) / 2, (y1 + y2) / 2, stddev);
+	split_region((x1 + x2) / 2, y1, x2, (y1 + y2) / 2, stddev);
+	split_region(x1, (y1 + y2) / 2, (x1 + x2) / 2, y2, stddev);
+	split_region((x1 + x2) / 2, (y1 + y2) / 2, x2, y2, stddev);
+}
 
-    split_image(image(cv::Range(0, height / 2), cv::Range(0, width / 2)), stddev);
-    split_image(image(cv::Range(0, height / 2), cv::Range(width / 2, width)), stddev);
-    split_image(image(cv::Range(height / 2, height), cv::Range(width / 2, width)), stddev);
-    split_image(image(cv::Range(height / 2, height), cv::Range(0, width / 2)), stddev);
+void split_image(cv::Mat& image, const double& stddev)
+{
+	cv::Mat int_img, squared_int_img;
+	cv::integral(image, integralImg, sqIntegralImg);
+
+	split_region(0, 0, image.cols, image.rows, stddev);
+}
+
+void merge_image(cv::Mat& image)
+{
+	auto elem = region_history.begin();
+	double next_val = elem->first + DELTA_MEAN;
+	while (elem != region_history.end())
+	{
+		if (elem->first > next_val)
+			next_val += DELTA_MEAN;
+		image(elem->second.first, elem->second.second).setTo(int(next_val - DELTA_MEAN / 2));
+		elem++;
+	}
+	
 }
 } // namespace
 
@@ -35,11 +67,17 @@ namespace cvlib
 cv::Mat split_and_merge(const cv::Mat& image, double stddev)
 {
     // split part
-    cv::Mat res = image;
+    cv::Mat res = image; // copy
     split_image(res, stddev);
 
     // merge part
-    // \todo implement merge algorithm
+	merge_image(res);
+
+	// clear global vars
+	integralImg.release();
+	sqIntegralImg.release();
+	region_history.clear();
+
     return res;
 }
 } // namespace cvlib

--- a/demo/demo_split_and_merge.cpp
+++ b/demo/demo_split_and_merge.cpp
@@ -14,8 +14,10 @@ int demo_split_and_merge(int argc, char* argv[])
     if (!cap.isOpened())
         return -1;
 
-    cv::Mat frame;
+    cv::Mat frame, copy_frame;
     cv::Mat frame_gray;
+    cv::Mat split_and_merge;
+    cv::Mat diff, split;
 
     const auto origin_wnd = "origin";
     const auto demo_wnd = "demo";
@@ -30,8 +32,15 @@ int demo_split_and_merge(int argc, char* argv[])
         cap >> frame;
 
         cv::cvtColor(frame, frame_gray, cv::COLOR_BGR2GRAY);
+        frame_gray.copyTo(copy_frame);
         cv::imshow(origin_wnd, frame);
-        cv::imshow(demo_wnd, cvlib::split_and_merge(frame_gray, stddev));
+        
+        split_and_merge = cvlib::split_and_merge(frame_gray, stddev);
+        cv::imshow(demo_wnd, split_and_merge);
+        split = cvlib::only_split(copy_frame, stddev);
+        cv::absdiff(split_and_merge, split, diff);
+        cv::imshow("diff", diff * 20);
+		
     }
 
     cv::destroyWindow(origin_wnd);


### PR DESCRIPTION
Можно ускорить **split** часть алгоритма, если использовать для подсчета мат ожидания и дисперсии интегральные представления изображения, что я и реализовал.
Для **merge** части ничего лучше, чем объединение областей с близкими мат ожиданиями не смог придумать, грубо говоря получилось квантование всех областей с определенным шагом квантования.